### PR TITLE
Extend validator for anchors links

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -34,6 +34,7 @@ function extendPath(filepath) {
 function checkAnchor(dom, sourcefile, destinationPath, files) {
 	const validatableAnchor = anchor =>
 		!anchor.attribs.href.startsWith('#') &&
+	      	!anchor.attribs.href.startsWith('/#') &&
 		!anchor.attribs.href.startsWith('http://') &&
 		!anchor.attribs.href.startsWith('https://') &&
 		!anchor.attribs.href.startsWith('mailto:');

--- a/src/validator.js
+++ b/src/validator.js
@@ -34,7 +34,7 @@ function extendPath(filepath) {
 function checkAnchor(dom, sourcefile, destinationPath, files) {
 	const validatableAnchor = anchor =>
 		!anchor.attribs.href.startsWith('#') &&
-	      	!anchor.attribs.href.startsWith('/#') &&
+		!anchor.attribs.href.startsWith('/#') &&
 		!anchor.attribs.href.startsWith('http://') &&
 		!anchor.attribs.href.startsWith('https://') &&
 		!anchor.attribs.href.startsWith('mailto:');


### PR DESCRIPTION
Sometime you might want to link to anchors on another pages so link that starts with "/#" should be considered valid.